### PR TITLE
Qk 53 ast implement generation for all keyword types

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -85,6 +85,37 @@ pub fn generate_ast(tokens: Vec<Token>, file_path: &str) -> Vec<Box<ASTNode>> {
                 continue;
             }
 
+            if token.token_type == TokenType::KeywordReturn {
+                let mut return_init: Box<ASTNode> = Box::new(ASTNode::new(token));
+                let mut return_tokens: Vec<&Token> = Vec::new();
+
+                let mut j: usize = i + 1;
+                while j < tokens.len() && tokens[j].token_type != TokenType::OperatorSemicolon && tokens[j].token_type != TokenType::EOL {
+                    return_tokens.push(&tokens[j]);
+                    j += 1;
+                }
+
+                i = j;
+
+                for token in return_tokens {
+                    return_init.children.push(Box::new(ASTNode::new(token)));
+                }
+
+                if i < tokens.len() && tokens[i].token_type == TokenType::OperatorSemicolon {
+                    return_init.children.push(Box::new(ASTNode::new(&tokens[i])));
+                    current_parent = Some(return_init);
+                } else {
+                    let _err = Err::new(
+                        ErrorType::Syntax,
+                        "Missing semicolon",
+                        token.line,
+                        token.column
+                    ).with_file(file_path).panic();
+                }
+
+                continue;
+            }
+
             if token.token_type == TokenType::KeywordLet {
                 let mut var_tokens: Vec<&Token> = Vec::new();
                 let mut variable_init: Box<ASTNode> = Box::new(ASTNode::new(token));

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -2,6 +2,7 @@
 
 use crate::lexer::{Token, TokenType};
 use crate::error_handler::*;
+use regex::Regex;
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct ASTNode {
@@ -27,6 +28,92 @@ pub fn generate_ast(tokens: Vec<Token>, file_path: &str) -> Vec<Box<ASTNode>> {
 
     while i < tokens.len() {
         let token: &Token = &tokens[i];
+
+        let current_token_type_str = format!("{:?}", token.token_type);
+        let keyword_regex = Regex::new(r"^Keyword.*").unwrap();
+
+        // Check if token.token_type starts with Keyword
+        if keyword_regex.is_match(&current_token_type_str) {
+            // Maybe put checks for token.token_type in a match
+
+            if token.token_type == TokenType::KeywordFn {
+                let mut fn_init_tokens: Vec<&Token> = Vec::new();
+                let mut fn_int: Box<ASTNode> = Box::new(ASTNode::new(token));
+
+                let mut j: usize = i + 1;
+                while j < tokens.len() && tokens[j].token_type != TokenType::PunctuationBraceOpen {
+                    fn_init_tokens.push(&tokens[j]);
+                    j += 1;
+                }
+
+                i = j
+
+                // fn_init.children = generate_ast_fn_init(fn_init_tokens, file_path);
+
+                // TODO: Handle function body
+            }
+
+            if token.token_type == TokenType::KeywordFree {
+                let mut free_init: Box<ASTNode> = Box::new(ASTNode::new(token));
+                let mut free_tokens: Vec<&Token> = Vec::new();
+
+                let mut j: usize = i + 1;
+
+                while j < tokens.len() && tokens[j].token_type != TokenType::OperatorSemicolon && tokens[j].token_type != TokenType::EOL {
+                    free_tokens.push(&tokens[j]);
+                    j += 1;
+                }
+
+                i = j;
+
+                for token in free_tokens {
+                    free_init.children.push(Box::new(ASTNode::new(token)));
+                }
+
+                if i < tokens.len() && tokens[i].token_type == TokenType::OperatorSemicolon {
+                    free_init.children.push(Box::new(ASTNode::new(&tokens[i])));
+                    current_parent = Some(free_init);
+                } else {
+                    let _err = Err::new(
+                        ErrorType::Syntax,
+                        "Missing semicolon",
+                        token.line,
+                        token.column
+                    ).with_file(file_path).panic();
+                }
+
+                continue;
+            }
+
+            if token.token_type == TokenType::KeywordLet {
+                let mut var_tokens: Vec<&Token> = Vec::new();
+                let mut variable_init: Box<ASTNode> = Box::new(ASTNode::new(token));
+
+                let mut j: usize = i + 1;
+                while j < tokens.len() && tokens[j].token_type != TokenType::OperatorSemicolon && tokens[j].token_type != TokenType::EOL {
+                    var_tokens.push(&tokens[j]);
+                    j += 1;
+                }
+
+                i = j;
+
+                variable_init.children = generate_ast_variable(var_tokens, file_path);
+
+                if i < tokens.len() && tokens[i].token_type == TokenType::OperatorSemicolon {
+                    variable_init.children.push(Box::new(ASTNode::new(&tokens[i])));
+                    current_parent = Some(variable_init);
+                } else {
+                    let _err = Err::new(
+                        ErrorType::Syntax,
+                        "Missing semicolon",
+                        token.line,
+                        token.column
+                    ).with_file(file_path).panic();
+                }
+
+                continue;
+            }
+        }
 
         if token.token_type == TokenType::Identifier{
             let is_next_token_assign: bool = if i + 1 < tokens.len() && tokens[i + 1].token_type == TokenType::OperatorAssign {true} else {false};
@@ -58,35 +145,6 @@ pub fn generate_ast(tokens: Vec<Token>, file_path: &str) -> Vec<Box<ASTNode>> {
                 }
                 continue;
             }
-        }
-
-        if token.token_type == TokenType::KeywordLet {
-            let mut var_tokens: Vec<&Token> = Vec::new();
-            let mut variable_init: Box<ASTNode> = Box::new(ASTNode::new(token));
-
-            let mut j: usize = i + 1;
-            while j < tokens.len() && tokens[j].token_type != TokenType::OperatorSemicolon && tokens[j].token_type != TokenType::EOL {
-                var_tokens.push(&tokens[j]);
-                j += 1;
-            }
-
-            i = j;
-
-            variable_init.children = generate_ast_variable(var_tokens, file_path);
-
-            if i < tokens.len() && tokens[i].token_type == TokenType::OperatorSemicolon {
-                variable_init.children.push(Box::new(ASTNode::new(&tokens[i])));
-                current_parent = Some(variable_init);
-            } else {
-                let _err = Err::new(
-                    ErrorType::Syntax,
-                    "Missing semicolon",
-                    token.line,
-                    token.column
-                ).with_file(file_path).panic();
-            }
-
-            continue;
         }
 
         if token.token_type == TokenType::OperatorSemicolon {

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -38,7 +38,7 @@ pub fn generate_ast(tokens: Vec<Token>, file_path: &str) -> Vec<Box<ASTNode>> {
 
             if token.token_type == TokenType::KeywordFn {
                 let mut fn_init_tokens: Vec<&Token> = Vec::new();
-                let mut fn_int: Box<ASTNode> = Box::new(ASTNode::new(token));
+                let mut fn_init: Box<ASTNode> = Box::new(ASTNode::new(token));
 
                 let mut j: usize = i + 1;
                 while j < tokens.len() && tokens[j].token_type != TokenType::PunctuationBraceOpen {

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -207,7 +207,7 @@ fn match_keyword(word: &str) -> Option<TokenType> {
         "immut" => Some(TokenType::KeywordImmut),
         "let" => Some(TokenType::KeywordLet),
         "heap!" => Some(TokenType::KeywordHeap),
-        "free()" => Some(TokenType::KeywordFree),
+        "free" => Some(TokenType::KeywordFree),
         "return" => Some(TokenType::KeywordReturn),
         "construct" => Some(TokenType::KeywordConstruct),
         "if" => Some(TokenType::KeywordIf),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of various keyword statements (`fn`, `free`, `return`, `let`) to ensure consistent parsing and error checking for missing semicolons.
	- Adjusted keyword recognition so that `free` is now correctly identified without requiring parentheses.

- **Refactor**
	- Streamlined parsing logic for keywords and assignments, making error handling and token collection more consistent across different constructs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->