### PR TITLE
Updated parent system to have a scope stack and a better handling for the current parent

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -257,24 +257,6 @@ fn pop_parent_node(mut scope_stack: Vec<Rc<RefCell<Box<ASTNode>>>>, current_pare
     (scope_stack, Rc::clone(current_parent))
 }
 
-// fn pop_parent_node<'a>(mut scope_stack: Vec<&'a mut Box<ASTNode>>, current_parent: &mut &'a mut Box<ASTNode>, ) -> (Vec<&'a mut Box<ASTNode>>, &'a mut Box<ASTNode>) {
-//     if !scope_stack.is_empty() {
-//         scope_stack.pop();
-//         if let Some(last) = scope_stack.last_mut() {
-//             *current_parent = *last;
-//         } else {
-//             let _err = Err::new(
-//                 ErrorType::Other,
-//                 "Internal Error: Scope stack is empty — no valid current_parent!",
-//                 0,
-//                 0
-//             ).panic();
-//         }
-//     }
-//
-//     (scope_stack, current_parent)
-// }
-
 /// Generates an Abstract Syntax Tree (AST) from a function call.
 ///
 /// # Parameters

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -33,7 +33,9 @@ pub enum TokenType {
     PunctuationParenOpen, PunctuationParenClose, PunctuationBraceOpen, PunctuationBraceClose, PunctuationBracketOpen, PunctuationBracketClose,
     PunctuationDot, PunctuationComma, PunctuationColon,
     // Special Tokens
-    EOL, EOF, Unknown
+    EOL, EOF, Unknown,
+    // AST Generator Helpers
+    Root
 }
 
 #[derive(Debug)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,9 +7,9 @@ pub mod error_handler;
 fn main() {
     let tokens: Vec<lexer::Token> = lexer::get_tokens("/home/raphael/Development/Quirk/test.qk");
 
-    debug_print_tokens(&tokens);
+    // debug_print_tokens(&tokens);
 
-    let ast: Vec<Box<ast::ASTNode>> = ast::generate_ast(tokens, "/home/raphael/Development/Quirk/test.qk");
+    let ast: Box<ast::ASTNode> = ast::generate_ast(tokens, "/home/raphael/Development/Quirk/test.qk");
 
     debug_print_ast(&ast);
 }
@@ -39,8 +39,6 @@ pub fn debug_print_tokens(tokens: &Vec<lexer::Token>) {
 /// This function iterates over each node in the AST and prints its debug
 /// representation to the console, aiding in debugging and visualization of
 /// the AST structure.
-pub fn debug_print_ast(ast: &Vec<Box<ast::ASTNode>>) {
-    for node in ast {
-        println!("{:#?}", node);
-    }
+pub fn debug_print_ast(node: &Box<ast::ASTNode>) {
+    println!("{:#?}", node);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,15 +30,16 @@ pub fn debug_print_tokens(tokens: &Vec<lexer::Token>) {
     }
 }
 
-/// Prints a formatted debug representation of the Abstract Syntax Tree (AST).
+
+/// Prints a debug representation of the AST to the console.
 ///
 /// # Parameters
 ///
-/// - `ast`: A reference to a vector of boxed `ASTNode`s representing the AST.
+/// - `node`: A reference to a boxed `ASTNode`.
 ///
-/// This function iterates over each node in the AST and prints its debug
-/// representation to the console, aiding in debugging and visualization of
-/// the AST structure.
+/// This function prints the debug representation of `node` and its children
+/// to the console, aiding in debugging and visualization of the Abstract
+/// Syntax Tree (AST).
 pub fn debug_print_ast(node: &Box<ast::ASTNode>) {
     println!("{:#?}", node);
 }


### PR DESCRIPTION
main.rs:
Updated debug_print_ast() function to not expect a vector of ASTNodes anymore

lexer.rs:
Added special AST generator token type

ast.rs
Implemented a proper scope stack and current parent system and changed the return type of generate_ast to just return a Box<ASTNode> instead of a Vec<Box<ASTNode>>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved the structure of the abstract syntax tree (AST) by consolidating it under a single root node, enhancing parent-child relationship management and scope handling.
  - Updated internal handling of AST nodes for better control and maintainability.

- **New Features**
  - Added a new token type to support AST generation.

- **Style**
  - Disabled debug output for tokens to reduce console clutter.

- **Documentation**
  - Added documentation comments for improved code clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->