### PR TITLE
Added ast generation for KeywordBreak and KeywordContinue

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -244,7 +244,7 @@ pub fn generate_ast(tokens: Vec<Token>, file_path: &str) -> Box<ASTNode> {
             }
 
 
-            if token.token_type == TokenType::KeywordElseIf {
+            if token.token_type == TokenType::KeywordElIf {
                 let mut elif_init:Box<ASTNode> = Box::new(ASTNode::new(token));
                 let mut condition_tokens: Vec<&Token> = Vec::new();
 
@@ -414,6 +414,24 @@ pub fn generate_ast(tokens: Vec<Token>, file_path: &str) -> Box<ASTNode> {
                 current_parent_ = code_block_clone;
 
                 continue;
+            }
+            
+            if token.token_type == TokenType::KeywordBreak || token.token_type == TokenType::KeywordContinue {
+                let node: Rc<RefCell<Box<ASTNode>>> = Rc::new(RefCell::new(Box::new(ASTNode::new(token))));
+
+                i += 1;
+                
+                if i < tokens.len() && tokens[i].token_type == TokenType::OperatorSemicolon {
+                    node.borrow_mut().children.push(Rc::new(RefCell::new(Box::new(ASTNode::new(&tokens[i])))));
+                    current_parent_.borrow_mut().children.push(node);
+                } else {
+                    let _err = Err::new(
+                        ErrorType::Syntax,
+                        "Missing semicolon",
+                        token.line,
+                        token.column
+                    ).with_file(file_path).panic();
+                }
             }
         }
 

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -12,8 +12,8 @@ use crate::error_handler::*;
 pub enum TokenType {
     // Keywords
     KeywordFn, KeywordImmut, KeywordLet, KeywordHeap, KeywordFree, KeywordReturn,
-    KeywordConstruct, KeywordIf, KeywordElse, KeywordElseIf, KeywordFor, KeywordWhile, KeywordBreak,
-    KeywordContinue, KeywordImport, KeywordAsync, KeywordAwait, KeywordCase, KeywordEnum,
+    KeywordIf, KeywordElse, KeywordElIf, KeywordFor, KeywordWhile, KeywordBreak,
+    KeywordContinue, KeywordConstruct, KeywordImport, KeywordAsync, KeywordAwait, KeywordCase, KeywordEnum,
     KeywordClass, KeywordStruct, KeywordOut, KeywordIsOk, KeywordIsErr, KeywordNew,
     // Data Types
     DataTypeInt, DataTypeUint, DataTypeInt8, DataTypeUint8, DataTypeInt16, DataTypeUint16,
@@ -227,7 +227,7 @@ fn match_keyword(word: &str) -> Option<TokenType> {
         "return" => Some(TokenType::KeywordReturn),
         "construct" => Some(TokenType::KeywordConstruct),
         "if" => Some(TokenType::KeywordIf),
-        "elif" => Some(TokenType::KeywordElseIf),
+        "elif" => Some(TokenType::KeywordElIf),
         "else" => Some(TokenType::KeywordElse),
         "for" => Some(TokenType::KeywordFor),
         "while" => Some(TokenType::KeywordWhile),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected keyword handling to recognize "elif" instead of "elseif".
  - Improved processing of "break" and "continue" statements, ensuring proper syntax validation and error reporting for missing semicolons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->